### PR TITLE
Добавлены Shift+Ctrl и Shift+Alt для переключения языков

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@
 ```
 LANG_CHANGE_CAPS
 LANG_CHANGE_ALT_SHIFT
+LANG_CHANGE_SHIFT_ALT
 LANG_CHANGE_CTRL_SHIFT
+LANG_CHANGE_SHIFT_CTRL
 LANG_CHANGE_WIN_SPACE
 ```
 
@@ -37,7 +39,9 @@ LANG_CHANGE_WIN_SPACE
 ```c
 LA_CAPS, /* Задаёт переключение языка на Caps. */
 LA_ALSH, /* Задаёт переключение языка на Alt + Shift. */
+LA_SHAL, /* Задаёт переключение языка на Shift + Alt. На Win10 это позволяет избежать появления окна переключения языков. */
 LA_CTSH, /* Задаёт переключение языка на Ctrl + Shift. */
+LA_SHCT, /* Задаёт переключение языка на Shift + Ctrl. На Win10 это позволяет избежать появления окна переключения языков. */
 LA_WISP, /* Задаёт переключение языка на Win + Space. */
 ```
 

--- a/include.h
+++ b/include.h
@@ -276,6 +276,7 @@ enum lang_shift_keycodes {
 	LA_SYNC, /* Кнопка для синхронизации языков. Её нужно нажимать в случае если язык в системе и язык в клавиатуре различаются. Данная клавиша изменит язык в системе. */
 	LA_CAPS, /* Задаёт переключение языка на Caps. */
 	LA_ALSH, /* Задаёт переключение языка на Alt + Shift. */
+	LA_SHAL, /* Задаёт переключение языка на Shift + Alt. На Win10 это позволяет избежать появления окна переключения языков. */
 	LA_CTSH, /* Задаёт переключение языка на Ctrl + Shift. */
 	LA_SHCT, /* Задаёт переключение языка на Shift + Ctrl. На Win10 это позволяет избежать появления окна переключения языков. */
 	LA_WISP, /* Задаёт переключение языка на Win + Shift. */
@@ -300,6 +301,7 @@ typedef uint8_t Shift;
 enum LangChange {
   LANG_CHANGE_CAPS,
   LANG_CHANGE_ALT_SHIFT,
+  LANG_CHANGE_SHIFT_ALT,
   LANG_CHANGE_CTRL_SHIFT,
   LANG_CHANGE_SHIFT_CTRL,
   LANG_CHANGE_WIN_SPACE

--- a/include.h
+++ b/include.h
@@ -277,6 +277,7 @@ enum lang_shift_keycodes {
 	LA_CAPS, /* Задаёт переключение языка на Caps. */
 	LA_ALSH, /* Задаёт переключение языка на Alt + Shift. */
 	LA_CTSH, /* Задаёт переключение языка на Ctrl + Shift. */
+	LA_SHCT, /* Задаёт переключение языка на Shift + Ctrl. На Win10 это позволяет избежать появления окна переключения языков. */
 	LA_WISP, /* Задаёт переключение языка на Win + Shift. */
 
 	/* -------------------------------------------------------------------- */
@@ -300,6 +301,7 @@ enum LangChange {
   LANG_CHANGE_CAPS,
   LANG_CHANGE_ALT_SHIFT,
   LANG_CHANGE_CTRL_SHIFT,
+  LANG_CHANGE_SHIFT_CTRL,
   LANG_CHANGE_WIN_SPACE
 };
 

--- a/src.c
+++ b/src.c
@@ -348,6 +348,17 @@ void lang_synchronize(void) {
         register_code(KC_LSHIFT);
       }
     } break;
+    case LANG_CHANGE_SHIFT_ALT: {
+      register_code(KC_LSHIFT);
+      register_code(KC_LALT);
+      unregister_code(KC_LALT);
+      unregister_code(KC_LSHIFT);
+
+      // Костыль, потому что при зажатом шифте если хочется нажать клавишу, которая переключает язык, то шифт слетает... 
+      if (shift_current == 1) {
+        register_code(KC_LSHIFT);
+      }
+    } break;
     case LANG_CHANGE_CTRL_SHIFT: {
       register_code(KC_LCTRL);
       register_code(KC_LSHIFT);
@@ -498,6 +509,11 @@ bool lang_shift_process_custom_keycodes(Key key, keyrecord_t* record) {
     case LA_ALSH:
       if (down) {
         lang_current_change = LANG_CHANGE_ALT_SHIFT;
+      }
+      return false;
+    case LA_SHAL:
+      if (down) {
+        lang_current_change = LANG_CHANGE_SHIFT_ALT;
       }
       return false;
     case LA_CTSH:

--- a/src.c
+++ b/src.c
@@ -359,6 +359,17 @@ void lang_synchronize(void) {
         register_code(KC_LSHIFT);
       }
     } break;
+    case LANG_CHANGE_SHIFT_CTRL: {
+      register_code(KC_LSHIFT);
+      register_code(KC_LCTRL);
+      unregister_code(KC_LCTL);
+      unregister_code(KC_LSHIFT);
+
+      // Костыль, потому что при зажатом шифте если хочется нажать клавишу, которая переключает язык, то шифт слетает...
+      if (shift_current == 1) {
+        register_code(KC_LSHIFT);
+      }
+    } break;
     case LANG_CHANGE_WIN_SPACE: {
       register_code(KC_LGUI);
       register_code(KC_SPACE);
@@ -492,6 +503,11 @@ bool lang_shift_process_custom_keycodes(Key key, keyrecord_t* record) {
     case LA_CTSH:
       if (down) {
         lang_current_change = LANG_CHANGE_CTRL_SHIFT;
+      }
+      return false;
+    case LA_SHCT:
+      if (down) {
+        lang_current_change = LANG_CHANGE_SHIFT_CTRL;
       }
       return false;
     case LA_WISP:


### PR DESCRIPTION
Добавил альтернативные способы перключения языков: помимо Ctrl+Shift и Alt+Shift добавлены обратные комбинации.
На Windows 10 начиная с какой-то версии использование Ctrl+Shift приводит к кратковременному появлению окна переключения языков. И если быстро переключать языки, то это окно, бывает, подвисает.

Если же использовать Shift+Ctrl, то переключение происходит без появления окна, быстрее и зависаний не обнаруживал.